### PR TITLE
Use the ITestService interface instead of the TestService directly.

### DIFF
--- a/src/hurry/Program.cs
+++ b/src/hurry/Program.cs
@@ -4,8 +4,8 @@ namespace hurry;
 
 public static class Program
 {
-    private static readonly TestService _testService =
-        new(new TimerService(), new PromptService(), new ResultsService());
+    private static readonly ITestService _testService =
+        new TestService(new TimerService(), new PromptService(), new ResultsService());
 
     private static async Task Main()
     {


### PR DESCRIPTION
The ITestService interface members were not being used because TestService was instantiated and assigned to a variable of type TestService instead of ITestService. 